### PR TITLE
added adminer and useable postgresql image

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:15.2-alpine
+
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY ./create-pong-user.sh /docker-entrypoint-initdb.d/
+COPY ./init-db-tables.sql /docker-entrypoint-initdb.d/

--- a/database/create-pong-user.sh
+++ b/database/create-pong-user.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username $POSTGRES_USER --dbname $POSTGRES_DB <<-EOSQL
+        CREATE USER $PONG_DB_USER WITH PASSWORD '$PONG_DB_PASSWORD';
+        ALTER DEFAULT PRIVILEGES
+                FOR USER $POSTGRES_USER
+                IN SCHEMA public
+                GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $PONG_DB_USER;
+EOSQL

--- a/database/init-db-tables.sql
+++ b/database/init-db-tables.sql
@@ -1,0 +1,6 @@
+CREATE TABLE users (
+    user_id int,
+    username char(255),
+    wins int,
+    losses int
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,22 +7,37 @@ services:
     restart: always
     ports:
       - "5574:5574"
+    networks:
+      - pong-network
     volumes:
       - frontend-volume:/home/frontend-volume
   backend:
     container_name: pong-backend
     build: ./backend/
     restart: always
+    networks:
+      - pong-network
     volumes:
       - backend-volume:/home/backend-volume
   postgres_db:
     container_name: pong-database
-    image: postgres:15.2-alpine
+    build: ./database/
     restart: always
     env_file:
       - .env
+    ports:
+      - 5432:5432
+    networks:
+      - pong-network
     volumes:
       - database:/var/lib/postgresql/data
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+    networks:
+      - pong-network
 networks:
   pong-network:
     driver: bridge


### PR DESCRIPTION
I added the Adminer docker image to the compose file, as a temporary development tool. It hosts a local website which you can use to login to and interact with the postgresql database. Useful while working on database-related code.

We also build the postgresql image, because setup required writing our own entrypoint.sh and .sql files.