### PR TITLE
Docker compose environment variables clarity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,12 @@ services:
     container_name: pong-database
     build: ./database/
     restart: always
-    env_file:
-      - .env
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - PONG_DB_USER=${PONG_DB_USER}
+      - PONG_DB_PASSWORD=${PONG_DB_PASSWORD}
     ports:
       - 5432:5432
     networks:


### PR DESCRIPTION
The environment variables for the Postgresql container are now clearly listed in the docker compose file under the environment directive, a '.env' file is still needed but the required variables are now listed too.