### PR TITLE
Combine `/frontend/volume/.env` and `/.env` into `/.env`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: pong-frontend
     build: ./frontend/
     restart: always
+    env_file:
+      - .env
     ports:
       - 5574:5574
     networks:


### PR DESCRIPTION
`VITE_CLIENT_UID` should now be specified in `/.env`
(Yes you still need `CLIENT_UID`, and yes they should hold the same value)