### PR TITLE
first group message fix

### DIFF
--- a/frontend/volume/src/components/chat/Overview.tsx
+++ b/frontend/volume/src/components/chat/Overview.tsx
@@ -108,7 +108,7 @@ function Overview({
 						lastMessage: {
 							...old_group_chat.lastMessage,
 							author: {
-								...old_group_chat.lastMessage.author,
+								...old_group_chat.lastMessage?.author,
 								blocked_by_me: message_received.message.author.blocked_by_me,
 							},
 							content: message_received.message.content,


### PR DESCRIPTION
overview only checks for last author if last message exists, so the first group message is rendered 